### PR TITLE
cage: update

### DIFF
--- a/recipes-wlroots/cage/cage_git.bb
+++ b/recipes-wlroots/cage/cage_git.bb
@@ -1,4 +1,3 @@
-
 SUMMARY = "Cage: a Wayland kiosk"
 HOMEPAGE = "https://www.hjdskes.nl/projects/cage/"
 LICENSE = "MIT"
@@ -17,11 +16,10 @@ inherit meson pkgconfig features_check
 
 REQUIRED_DISTRO_FEATURES = "wayland"
 
-SRC_URI = "git://github.com/Hjdskes/${BPN}.git;branch=master;protocol=https"
-SRCREV = "46f0ec1b729cf2e4fb9c69bb8660e908d1311ea0"
-PV = "0.1.4"
+SRC_URI = "git://github.com/cage-kiosk/cage;branch=master;protocol=https"
+SRCREV = "bd5b20e1fab67d7fb548ecde0aade8455df4509c"
+PV = "0.1.4+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'xwayland', d)}"
 PACKAGECONFIG[xwayland] = "-Dxwayland=true,-Dxwayland=false,xserver-xorg,xwayland"
-


### PR DESCRIPTION
- support for wlr_virtual_keyboard and wlr_virtual_pointer may be used for VNC
- use organization url to retrieve the repository
- add git revision to PV