### PR TITLE
-Wno-switch added to foot for value 'XDG_TOPLEVEL_STATE_SUSPENDED' 

### DIFF
--- a/recipes-support/foot/foot_git.bb
+++ b/recipes-support/foot/foot_git.bb
@@ -41,6 +41,7 @@ EXTRA_OEMESON += "--buildtype=release -Dterminfo=disabled"
 inherit meson pkgconfig
 
 CFLAGS += "-Wno-unused-but-set-variable"
+CFLAGS += "-Wno-switch"
 
 FILES:${PN} = " \
 	${bindir} \


### PR DESCRIPTION
Warning when compiling foot as a dep of sway

```
| ../git/wayland.c: In function 'xdg_toplevel_configure':
| ../git/wayland.c:655:9: error: enumeration value 'XDG_TOPLEVEL_STATE_SUSPENDED' not handled in switch [-Werror=switch]
|   655 |         switch (*state) {
|       |         ^~~~~~
| cc1: all warnings being treated as errors
| ninja: build stopped: subcommand failed.
| INFO: autodetecting backend as ninja
| INFO: calculating backend command to run: /home/omar/source/repos/tfc-os/build/tmp/work/cortexa72-poky-linux/foot/1.14.0-r0/recipe-sysroot-native/usr/bin/ninja -j 30 -v
| WARNING: /home/omar/source/repos/tfc-os/build/tmp/work/cortexa72-poky-linux/foot/1.14.0-r0/temp/run.do_compile.126243:153 exit 1 from 'meson compile -v -j 30'
| WARNING: Backtrace (BB generated script):
|       #1: meson_do_compile, /home/omar/source/repos/tfc-os/build/tmp/work/cortexa72-poky-linux/foot/1.14.0-r0/temp/run.do_compile.126243, line 153
|       #2: do_compile, /home/omar/source/repos/tfc-os/build/tmp/work/cortexa72-poky-linux/foot/1.14.0-r0/temp/run.do_compile.126243, line 148
|       #3: main, /home/omar/source/repos/tfc-os/build/tmp/work/cortexa72-poky-linux/foot/1.14.0-r0/temp/run.do_compile.126243, line 157
ERROR: Task (/home/omar/source/repos/tfc-os/meta-wayland/recipes-support/foot/foot_git.bb:do_compile) failed with exit code '1'
NOTE: Tasks Summary: Attempted 3757 tasks of which 3734 didn't need to be rerun and 1 failed.
```